### PR TITLE
Update svg-sprite.js

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -253,6 +253,12 @@ SVGSprite.prototype._addToSprite = function (svgID, svgInfo, svgPseudo, isLastSV
             this.data.sheight = Math.max(this.data.sheight, dimensions.height);
             break;
 
+        // No sprite arrangement
+        case 'none':
+            positionX = null;
+            positionY = null;
+            break;
+
         // Diagonal sprite arrangement
         case 'diagonal':
             if (!config.inline) {


### PR DESCRIPTION
Added simple "no sprite arrangment" for `layout` variable, so that SVG sprite can be used inline and then referenced with `<use xlink:href="#svg-id"/>'

I'm no coder, so _please check if my hackery works_! Seems to be all right…
