### PR TITLE
Allow node to clean up stack while processing

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -143,7 +143,7 @@ SVGSprite.prototype._cleanSVGO = function (file, svg, config, callback) {
 
             }
 
-            callback(null, svgObj);
+            process.nextTick(function() { callback(null, svgObj); });
         });
     } catch (error) {
 


### PR DESCRIPTION
Fixes https://github.com/shakyShane/gulp-svg-sprites/issues/89

The hidden error behind that issue was `RangeError: Maximum call stack size exceeded`, so I added a wait for the nextTick until processing the callback from the _clean function (this allows node.js to empty the current call stack before continuing).

On a minus side, there is a potential performance loss, but on my tests this wasn't noticeable.
