### PR TITLE
Adding SVG Children to sprite data for future transforms

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -359,6 +359,7 @@ SVGSprite.prototype._addToSprite = function (svgID, svgInfo, svgPseudo, isLastSV
         },
         data: data,
         raw: raw,
+        children: children,
         viewBox: viewBox
     });
 };


### PR DESCRIPTION
Adding SVG Children could be useful to do transform on output of your module `gulp-svg-sprites`. I need this commit to fix problem of gradients or clip path for svg symbols.