### PR TITLE
Upgrade `lodash` to patch vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules
 .idea
+
+npm-debug.log
+package-lock.json
+yarn.lock
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": "2.0.1",
     "css-selector-parser": "1.1.0",
     "cssom": "0.3.1",
-    "lodash": "4.14.1",
+    "lodash": "^4.17.11",
     "svg-cleaner": "0.0.4",
     "svgo": "0.6.6",
     "xml-parser": "^1.2.1"


### PR DESCRIPTION
This PR updates the `lodash` dependency version to patch the vulnerability found below. I also went ahead and ignored some common Yarn and NPM files.

```
✗ Low severity vulnerability found in lodash
  Description: Prototype Pollution
  Info: https://snyk.io/vuln/npm:lodash:20180130
  Introduced through: lodash@4.14.1
  From: lodash@4.14.1
  Remediation:
    Upgrade direct dependency lodash@4.14.1 to lodash@4.17.5 (triggers upgrades to lodash@4.17.5)
```

